### PR TITLE
small change in npzviewer.py

### DIFF
--- a/npzviewer/npzviewer.py
+++ b/npzviewer/npzviewer.py
@@ -50,9 +50,9 @@ class MainWindow(QtWidgets.QMainWindow):
         layout.addLayout(hlayout)
         layout.addWidget(self.plaintext)
         self.setAcceptDrops(True)
-        self.opemFileIfDropped(filelist)
-
+        
         vlayout = QtWidgets.QVBoxLayout()
+        
         self.keysCombo = QtWidgets.QComboBox(self)
         self.indexSpin = QtWidgets.QSpinBox(self)
         self.indexSpin.setSingleStep(1)
@@ -61,9 +61,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self.indexSpin.setVisible(False)
         self.matTable = QtWidgets.QTableWidget(self)
 
-        self.selected_nparr = np.array([])
+        self.opemFileIfDropped(filelist)
 
-        self.npz_loaded_file = ""
+        self.selected_nparr = np.array([])
 
         vlayout.addWidget(self.keysCombo)
         vlayout.addWidget(self.indexSpin)
@@ -149,7 +149,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self.keysCombo.currentTextChanged.disconnect()
 
         self.keysCombo.clear()
-        self.keysCombo.addItems(list(self.npz_loaded_file.keys()))
+        self.npz_keys = list(self.npz_loaded_file.keys())
+        self.keysCombo.addItems(self.npz_keys)
 
         self.keysCombo.currentTextChanged.connect(self.comboKeyChanged)
 
@@ -163,6 +164,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def opemFileIfDropped(self, filelist):
         if (isinstance(filelist, str)):
             if (".npz" in filelist):
+                print(filelist)
                 self.openFileByName(filelist)
 
         else:


### PR DESCRIPTION
Fixed some small bugs:
1.  Changes the order of object creation for self.keysCombo.
     Current order gives:
     AttributeError: 'MainWindow' object has no attribute 'keysCombo'

2. removed line : self.npz_loaded_file = ""
    Due to this line, when we pass .npz file using terminal we get key error due to empty npz_loaded_file.